### PR TITLE
Esp8266 deep sleep

### DIFF
--- a/targets/esp8266/jswrap_esp8266.c
+++ b/targets/esp8266/jswrap_esp8266.c
@@ -472,13 +472,12 @@ void jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData) {
 
 void   jswrap_ESP8266_deepSleep(JsVar *jsMicros) {
 
-    jsiConsolePrintf("In deepSleep()\n");
+    //jsiConsolePrintf("In deepSleep()\n");
     if (!jsvIsInt(jsMicros)) {
     jsExceptionHere(JSET_ERROR, "Invalid microseconds.");
          return;
     }
     int sleepTime = jsvGetInteger(jsMicros);
-    jsiConsolePrintf("sleepTime: %d\n", sleepTime);
 
     system_deep_sleep(sleepTime);
 

--- a/targets/esp8266/jswrap_esp8266.c
+++ b/targets/esp8266/jswrap_esp8266.c
@@ -457,3 +457,29 @@ void jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData) {
 
 #endif
 }
+
+
+/*JSON{
+  "type"     : "staticmethod",
+  "class"    : "ESP8266",
+  "name"     : "deepSleep",
+  "generate" : "jswrap_ESP8266_deepSleep",
+  "params"   : [
+    ["micros", "JsVar", "Number of microseconds to sleep."]
+  ]
+
+}*/
+
+void   jswrap_ESP8266_deepSleep(JsVar *jsMicros) {
+
+    jsiConsolePrintf("In deepSleep()\n");
+    if (!jsvIsInt(jsMicros)) {
+    jsExceptionHere(JSET_ERROR, "Invalid microseconds.");
+         return;
+    }
+    int sleepTime = jsvGetInteger(jsMicros);
+    jsiConsolePrintf("sleepTime: %d\n", sleepTime);
+
+    system_deep_sleep(sleepTime);
+
+}

--- a/targets/esp8266/jswrap_esp8266.h
+++ b/targets/esp8266/jswrap_esp8266.h
@@ -39,6 +39,8 @@ void   jswrap_ESP8266_wifi_reset();
 
 void   jswrap_ESP8266_neopixelWrite(Pin pin, JsVar *jsArrayOfData);
 
+void   jswrap_ESP8266_deepSleep(JsVar *jsMicros);
+
 uint32_t crc32(uint8_t *buf, uint32_t len);
 
 #endif /* TARGETS_ESP8266_JSWRAP_ESP8266_H_ */


### PR DESCRIPTION
Deep Sleep implementation for ESP8266.  Requires wiring reset and gpio16 together.  Set byte 108 of esp_init_data_default.bin for various options.
